### PR TITLE
Upload file

### DIFF
--- a/.prettierrc
+++ b/.prettierrc
@@ -1,0 +1,15 @@
+{
+	"arrowParens": "avoid",
+	"bracketSpacing": true,
+	"insertPragma": false,
+	"bracketSameLine": false,
+	"printWidth": 80,
+	"proseWrap": "preserve",
+	"quoteProps": "as-needed",
+	"requirePragma": false,
+	"semi": true,
+	"singleQuote": false,
+	"tabWidth": 2,
+	"trailingComma": "all",
+	"useTabs": false
+}

--- a/README.md
+++ b/README.md
@@ -9,6 +9,8 @@ This project use the following technologies:
 - [uv](https://docs.astral.sh/uv/) - a drop-in replacement for `pip` (very similar to `npm`)
 - [fastapi](https://fastapi.tiangolo.com/) - backend framework 
 - [pymarc](https://gitlab.com/pymarc/pymarc) - parsing marc records
+- [tailwindcss](https://tailwindcss.com/) + [daisyui](https://daisyui.com/) - CSS utility libaries 
+- [Datastar](https://data-star.dev/) - Hypermedia framework for UI interactivity
 
 ## Development 
 1. Create a virtual environment for the project (basically an `npm install`)

--- a/datastar.py
+++ b/datastar.py
@@ -1,0 +1,19 @@
+from fastapi.responses import StreamingResponse
+
+
+def send_event(data: str, merge=False):
+    yield "event: datastar-fragment\n"
+    if merge:
+        yield "data: merge upsert_attributes\n"
+    yield "data: fragment\n"
+    for d in data.split("\n"):
+        yield f"data: {d}\n"
+    yield "\n"
+
+
+def stream_template(frag: str) -> StreamingResponse:
+    return StreamingResponse(
+        send_event(frag),
+        headers={"Cache-Control": "no-cache", "Connection": "keep-alive"},
+        media_type="text/event-stream",
+    )

--- a/main.py
+++ b/main.py
@@ -2,11 +2,32 @@ from fastapi import FastAPI, Request
 from fastapi.responses import HTMLResponse
 from fastapi.templating import Jinja2Templates
 from db import Database
+from jinja2 import Template
+from humanize import naturalsize
+
+from datastar import stream_template
 
 app = FastAPI()
 templates = Jinja2Templates(directory="templates")
 db = Database()
 
+
 @app.get("/", response_class=HTMLResponse)
 def read_root(request: Request):
     return templates.TemplateResponse(request=request, name="home.html")
+
+
+@app.post("/upload")
+async def upload_files(request: Request):
+    body = await request.json()
+    files = body["files"]
+    filesMimes = body["filesMimes"]
+    filesNames = body["filesNames"]
+    results = []
+    for file, mime, name in zip(files, filesMimes, filesNames):
+        humanize_len = naturalsize(len(file.encode("utf-8")))
+        results.append((name, mime, humanize_len))
+
+    temp: Template = templates.get_template("upload_result.html")
+    frag = temp.render(results=results)
+    return stream_template(frag)

--- a/parse.py
+++ b/parse.py
@@ -35,6 +35,7 @@ def parse_marc(content: bytes) -> list[MarcEntry]:
     entries: list[MarcEntry] = []
     for record in reader:
         if record is None:
+            # TODO: what to do with these exceptions
             # print(
             #     "Current chunk:",
             #     reader.current_chunk,

--- a/parse.py
+++ b/parse.py
@@ -1,0 +1,67 @@
+from pymarc import Field, MARCReader
+from typing import TypedDict
+
+
+class MarcEntry(TypedDict):
+    title: str | None
+    isbn: str | None
+    author: str | None
+    publisher: str | None
+    pub_year: str | None
+    issn: str | None
+    issnl: str | None
+    issn_title: str | None
+    sudoc: str | None
+    uniform_title: str | None
+    location: list[str]
+    series: list[str]
+    notes: list[str]
+    subjects: list[str]
+    physical_description: list[str]
+
+
+class MarcFile(TypedDict):
+    mime: str
+    size: str
+    entries: list[MarcEntry]
+
+
+def map_fields(fields: list[Field]) -> list[str]:
+    return list(map(lambda field: field.value(), fields))
+
+
+def parse_marc(content: bytes) -> list[MarcEntry]:
+    reader = MARCReader(content, file_encoding="latin-1")
+    entries: list[MarcEntry] = []
+    for record in reader:
+        if record is None:
+            # print(
+            #     "Current chunk:",
+            #     reader.current_chunk,
+            #     "was ignored because exceptions\n",
+            #     reader.current_exception,
+            #     "\n",
+            # )
+            continue
+
+        entries.append(
+            {
+                "title": record.title,
+                "isbn": record.isbn,
+                "author": record.author,
+                "publisher": record.publisher,
+                "pub_year": record.pubyear,
+                "issn": record.issn,
+                "issnl": record.issnl,
+                "issn_title": record.issn_title,
+                "sudoc": record.sudoc,
+                "uniform_title": record.uniformtitle,
+                "location": map_fields(record.location),
+                "series": map_fields(record.series),
+                "notes": map_fields(record.notes),
+                "subjects": map_fields(record.subjects),
+                "physical_description": map_fields(record.physicaldescription),
+            }
+        )
+
+    return entries

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,5 +6,6 @@ readme = "README.md"
 requires-python = ">=3.12"
 dependencies = [
     "fastapi[standard]>=0.115.4",
+    "humanize>=4.11.0",
     "pymarc>=5.2.2",
 ]

--- a/templates/home.html
+++ b/templates/home.html
@@ -1,14 +1,50 @@
-<html>
+<html data-theme="light">
+  <head>
+    <title>Home</title>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <link
+      href="https://cdn.jsdelivr.net/npm/daisyui@4.12.14/dist/full.min.css"
+      rel="stylesheet"
+      type="text/css"
+    />
+    <script src="https://cdn.tailwindcss.com"></script>
+    <script
+      type="module"
+      src="https://cdn.jsdelivr.net/npm/@sudodevnull/datastar@0.19.9/dist/datastar.min.js"
+      defer
+    ></script>
+  </head>
 
-<head>
-	<title>Home</title>
-	<meta charset="UTF-8">
-	<meta name="viewport" content="width=device-width, initial-scale=1.0">
-	<script src="https://cdn.tailwindcss.com"></script>
-</head>
-
-<body>
-	<h1 class="text-3xl font-bold underline">Hello world</h1>
-</body>
-
+  <body>
+    <div class="flex items-center justify-center h-screen">
+      <div id="file_upload" class="flex flex-col gap-2">
+        <label
+          class="form-control w-full max-w-xs"
+          data-store="{
+            'files': [],
+            'filesMimes': [],
+            'filesNames': []
+          }"
+        >
+          <div class="label">
+            <span class="label-text">Upload</span>
+          </div>
+          <input
+            class="file-input file-input-bordered w-full max-w-xs"
+            data-model="files"
+            type="file"
+            multiple
+          />
+        </label>
+        <button
+          class="btn"
+          data-on-click="$$post('/upload')"
+          data-show="$files?.length > 0"
+        >
+          Submit
+        </button>
+      </div>
+    </div>
+  </body>
 </html>

--- a/templates/home.html
+++ b/templates/home.html
@@ -35,13 +35,21 @@
             data-model="files"
             type="file"
             multiple
+            data-bind-disabled="$$isFetching('#ind')"
           />
         </label>
         <button
           class="btn"
-          data-on-click="$$post('/upload')"
           data-show="$files?.length > 0"
+          data-on-click="$$post('/upload')"
+          data-fetch-indicator="'#ind'"
+          data-bind-disabled="$$isFetching('#ind')"
         >
+          <span 
+            id="ind" 
+            class="loading loading-spinner" 
+            data-show="$$isFetching('#ind')"
+          /></span>
           Submit
         </button>
       </div>

--- a/templates/upload_result.html
+++ b/templates/upload_result.html
@@ -1,0 +1,22 @@
+<div class="overflow-x-auto" id="file_upload">
+  <table class="table">
+    <thead>
+      <tr>
+        <th></th>
+        <th>Name</th>
+        <th>Mime</th>
+        <th>Size</th>
+      </tr>
+    </thead>
+    <tbody>
+      {% for name, mime, size in results %}
+      <tr class="hover">
+        <th>{{loop.index}}</th>
+        <td>{{name}}</td>
+        <td>{{mime}}</td>
+        <td>{{size}}</td>
+      </tr>
+      {% endfor %}
+    </tbody>
+  </table>
+</div>

--- a/templates/upload_result.html
+++ b/templates/upload_result.html
@@ -6,15 +6,17 @@
         <th>Name</th>
         <th>Mime</th>
         <th>Size</th>
+        <th>Entries</th>
       </tr>
     </thead>
     <tbody>
-      {% for name, mime, size in results %}
+      {% for name, mime, size, entries in results %}
       <tr class="hover">
         <th>{{loop.index}}</th>
         <td>{{name}}</td>
         <td>{{mime}}</td>
         <td>{{size}}</td>
+        <td>{{entries}}</td>
       </tr>
       {% endfor %}
     </tbody>

--- a/uv.lock
+++ b/uv.lock
@@ -182,6 +182,15 @@ wheels = [
 ]
 
 [[package]]
+name = "humanize"
+version = "4.11.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/6a/40/64a912b9330786df25e58127194d4a5a7441f818b400b155e748a270f924/humanize-4.11.0.tar.gz", hash = "sha256:e66f36020a2d5a974c504bd2555cf770621dbdbb6d82f94a6857c0b1ea2608be", size = 80374 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/92/75/4bc3e242ad13f2e6c12e0b0401ab2c5e5c6f0d7da37ec69bc808e24e0ccb/humanize-4.11.0-py3-none-any.whl", hash = "sha256:b53caaec8532bcb2fff70c8826f904c35943f8cecaca29d272d9df38092736c0", size = 128055 },
+]
+
+[[package]]
 name = "idna"
 version = "3.10"
 source = { registry = "https://pypi.org/simple" }
@@ -378,12 +387,14 @@ version = "0.1.0"
 source = { virtual = "." }
 dependencies = [
     { name = "fastapi", extra = ["standard"] },
+    { name = "humanize" },
     { name = "pymarc" },
 ]
 
 [package.metadata]
 requires-dist = [
     { name = "fastapi", extras = ["standard"], specifier = ">=0.115.4" },
+    { name = "humanize", specifier = ">=4.11.0" },
     { name = "pymarc", specifier = ">=5.2.2" },
 ]
 


### PR DESCRIPTION
This PR will add the uploading file screen, along with marc file parsing (excel and ONIX will come later). A few corners were cut:
- Using script files to load in CSS and JS libraries. Since we're not deploying this app, this makes it easier to develop without adding a pipeline for `npm`
- Uploading files doesn't have rate limit or size limit. Similar reason to above.
- Error handling for non marc files. Will do this at a later PR when we have the DB.
To test the feature, go to `localhost:8000`. You can upload multiple marc files at once. 